### PR TITLE
Avoid formatting diff output

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ var (
 
 func printLines(v *gocui.View, lines []string) {
 	for _, line := range lines {
-		fmt.Fprintf(v, line)
+		fmt.Fprint(v, line)
 	}
 }
 


### PR DESCRIPTION
Before:
<img width="990" alt="bildschirmfoto 2018-01-02 um 22 33 00" src="https://user-images.githubusercontent.com/5585491/34500947-221610b2-f00d-11e7-9461-4dd9c2aa8e1c.png">

After:
<img width="990" alt="bildschirmfoto 2018-01-02 um 22 33 18" src="https://user-images.githubusercontent.com/5585491/34500958-27581eee-f00d-11e7-82e7-9090510177f2.png">

Notice the string formatting difference in the last line.