### PR TITLE
find and open conflict files from root git directory

### DIFF
--- a/conflict/parse.go
+++ b/conflict/parse.go
@@ -149,7 +149,16 @@ Run below command to change to a compatible conflict style
 
 func Find() (err error) {
 	cwd, _ := os.Getwd()
-	stdout, stderr, _ := RunCommand("git", cwd, "--no-pager", "diff", "--check")
+
+	stdout, stderr, _ := RunCommand("git", cwd, "rev-parse", "--show-toplevel")
+	if len(stderr) != 0 {
+		return errors.New(stderr)
+	} else if len(stdout) == 0 {
+		return errors.New("no git top-level path")
+	}
+	topLevelPath := string(strings.Split(stdout, "\n")[0])
+
+	stdout, stderr, _ = RunCommand("git", cwd, "--no-pager", "diff", "--check")
 
 	if len(stderr) != 0 {
 		return errors.New(stderr)
@@ -172,7 +181,7 @@ func Find() (err error) {
 	}
 
 	for fname := range diffMap {
-		absPath := path.Join(cwd, fname)
+		absPath := path.Join(topLevelPath, fname)
 		if err = ReadFile(absPath); err != nil {
 			return
 		}


### PR DESCRIPTION
`fac` could not open file with conflict if the user's current working directory differs from the git root directory. in this case `fac` writes something like "2018/01/28 22:12:43 open <...>: no such file or directory".

how to reproduce:
- say we have git repo /git/myrepo/ with subdir lib/ as a current working directory
- we also have file with conflict: /git/myrepo/main.go
- run `fac`
- the output will be "<...> open /git/myrepo/lib/main.go: no such file or directory"