### PR TITLE
Goreleaser: Remove dep on go in Brew formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,6 @@ brew:
   description: "Command line User Interface for fixing git conflicts"
   dependencies:
     - git
-    - go
   install: bin.install "fac"
 
 builds:


### PR DESCRIPTION
Since Go builds a static binary, there is no need to include it as a runtime dependency.