### PR TITLE
Issue: #44: (New feature) Add option to set default peeks aka context lines

### DIFF
--- a/binding/binding.go
+++ b/binding/binding.go
@@ -36,6 +36,7 @@ const (
 	QuitApplication       = "quit"
 	ShowHelp              = "help"
 	ContinuousEvaluation  = "cont_eval"
+	DefaultContextLines   = "default_context_lines"
 )
 
 // defaultBinding is used when the user has not specified any of the
@@ -54,6 +55,7 @@ var defaultBinding = Binding{
 	QuitApplication:       "q",
 	ShowHelp:              "h",
 	ContinuousEvaluation:  "false",
+	DefaultContextLines:   "2",
 }
 
 // LoadSettings looks for a user specified key-binding settings file - `$HOME/.fac.yml`

--- a/conflict/conflict.go
+++ b/conflict/conflict.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/alecthomas/chroma"
@@ -95,6 +96,22 @@ func (c *Conflict) Update(incoming []string) (err error) {
 	c.IncomingLines, c.ColoredIncomingLines = updated.IncomingLines, updated.ColoredIncomingLines
 	c.LocalLines, c.ColoredLocalLines = updated.LocalLines, updated.ColoredLocalLines
 	c.LocalPureLines = updated.LocalPureLines
+	return
+}
+
+// SetPeeks sets the TopPeek and BottomPeek peek values
+func (c *Conflict) SetPeeks(peekSetting string) (err error) {
+	// Set context lines to show
+	peek, err := strconv.ParseInt(peekSetting, 10, 32)
+	if err != nil {
+		return
+	}
+	if peek < 0 {
+		err = errors.New("Invalid peekSetting, expecting a positive number")
+		return
+	}
+	c.TopPeek = int(peek)
+	c.BottomPeek = int(peek)
 	return
 }
 

--- a/conflict/conflict_test.go
+++ b/conflict/conflict_test.go
@@ -110,6 +110,29 @@ func TestEqual(t *testing.T) {
 	testhelper.Assert(t, !(c1.Equal(&c3)), "%s and %s should not be equal", c1, c2)
 }
 
+func TestSetPeeks(t *testing.T) {
+	var testCases = []struct {
+		in       string
+		expected int
+		err      bool
+	}{
+		{"2", 2, false},
+		{"0", 0, false},
+		{"-2", 0, true},
+	}
+
+	c := Conflict{}
+
+	for _, tt := range testCases {
+		if err := c.SetPeeks(tt.in); err != nil {
+			testhelper.Assert(t, tt.err == true, "Didn't expect error to be returned, input: %s", tt.in)
+		}
+
+		testhelper.Assert(t, c.TopPeek == tt.expected, "TopPeek, expected: %s, returned: %s", tt.expected, c.TopPeek)
+		testhelper.Assert(t, c.BottomPeek == tt.expected, "BottomPeek, expected:  %s, returned: %s", tt.expected, c.BottomPeek)
+	}
+}
+
 func TestPaddingLines(t *testing.T) {
 	f := File{Lines: dummyFile.lines}
 	c := Conflict{

--- a/main.go
+++ b/main.go
@@ -50,7 +50,12 @@ func findConflicts() (files []conflict.File, err error) {
 	for i := range files {
 		file := &files[i]
 		for j := range file.Conflicts {
-			conflicts = append(conflicts, &file.Conflicts[j])
+			// Set context lines to show
+			c := &file.Conflicts[j]
+			if err = c.SetPeeks(keyBinding[binding.DefaultContextLines]); err != nil {
+				return
+			}
+			conflicts = append(conflicts, c)
 		}
 	}
 


### PR DESCRIPTION
This sets the default_context_lines to 2. Let me know if this is not intended. 