### PR TITLE
docs: 'go get' is no longer supported outside a module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ I never really liked any of the `mergetools` out there so I made a program that 
 Execute:
 
 ```bash
-$ go get github.com/mkchoi212/fac
+$ go install github.com/mkchoi212/fac@latest
 ```
 
 Or using [Homebrew 🍺](https://brew.sh)


### PR DESCRIPTION
hello, @mkchoi212 



## read me section - Deprecation of 'go get' for installing executables

https://go.dev/doc/go-get-install-deprecation


change bash script